### PR TITLE
Add caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/hynek/build-and-inspect-python-package/compare/v1.1...main)
 
+### Added
+
+- The the tools are now cached between runs. [#6](https://github.com/hynek/build-and-inspect-python-package/pull/6)
+
 
 ## [1.1](https://github.com/hynek/build-and-inspect-python-package/compare/v1.0...v1.1)
 
 ### Changed
 
-- Built packages are written to `/tmp` instead of into the source `dist/` directory. That means that this action leaves your directory clean.
-  [#7](https://github.com/hynek/build-and-inspect-python-package/pull/7)
+- Built packages are written to `/tmp` instead of into the source `dist/` directory. That means that this action leaves your directory clean. [#7](https://github.com/hynek/build-and-inspect-python-package/pull/7)
 
 
 ## [1.0](https://github.com/hynek/build-and-inspect-python-package/compare/v0.1...v1.0)

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,8 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+        cache: pip
+        cache-dependency-path: "${{ github.action_path }}/requirements/tools.txt"
 
     - name: Create venv for tools
       run: python3.10 -m venv /tmp/baipp

--- a/action.yml
+++ b/action.yml
@@ -18,11 +18,9 @@ runs:
     - name: Resolve tools path
       shell: bash
       run: |
+        # See https://github.com/hynek/build-and-inspect-python-package/pull/6
+        # why this is necessary.
         python -c "import os; print('BAIPP_HOME=%s' % (os.path.abspath('${{ github.action_path }}',)))" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-
-    - run: ls -al ${{ env.BAIPP_HOME }}
-      shell: bash
 
     - uses: actions/setup-python@v4
       with:
@@ -34,7 +32,7 @@ runs:
       run: python3.10 -m venv /tmp/baipp
       shell: bash
 
-    - run: /tmp/baipp/bin/python -m pip install -r ${{ github.action_path }}/requirements/tools.txt
+    - run: /tmp/baipp/bin/python -m pip install -r ${{ env.BAIPP_HOME }}/requirements/tools.txt
       shell: bash
 
     # Build SDist, then build wheel out of it.

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve tools path
+      shell: bash
+      run: |
+         python -c "import os; print(os.path.abspath('${{ github.action_path }}'))"
+
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,13 @@ runs:
     - name: Resolve tools path
       shell: bash
       run: |
-         python -c "import os; print(os.path.abspath('${{ github.action_path }}'))"
+         python -c "import os; print(os.path.abspath('BAIPP_HOME=${{ github.action_path }}'))" >> $GITHUB_ENV
 
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
         cache: pip
-        cache-dependency-path: "${{ github.action_path }}/requirements/tools.txt"
+        cache-dependency-path: "${{ env.BAIPP_HOME }}/requirements/tools.txt"
 
     - name: Create venv for tools
       run: python3.10 -m venv /tmp/baipp

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ runs:
       run: |
          python -c "import os; print(os.path.abspath('BAIPP_HOME=${{ github.action_path }}'))" >> $GITHUB_ENV
 
+    - run: ls -al ${{ env.BAIPP_HOME }}
+      shell: bash
+
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ runs:
     - name: Resolve tools path
       shell: bash
       run: |
-         python -c "import os; print(os.path.abspath('BAIPP_HOME=${{ github.action_path }}'))" >> $GITHUB_ENV
-         cat $GITHUB_ENV
+        python -c "import os; print('BAIPP_HOME=%s' % (os.path.abspath('${{ github.action_path }}',)))" >> $GITHUB_ENV
+        cat $GITHUB_ENV
 
     - run: ls -al ${{ env.BAIPP_HOME }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ runs:
       shell: bash
       run: |
          python -c "import os; print(os.path.abspath('BAIPP_HOME=${{ github.action_path }}'))" >> $GITHUB_ENV
+         cat $GITHUB_ENV
 
     - run: ls -al ${{ env.BAIPP_HOME }}
       shell: bash


### PR DESCRIPTION
Unfortunately, the ** syntax doesn't work outside of our repo.

Trying to set

```yaml
cache-dependency-path: "${{ github.action_path }}/requirements/tools.txt"
```

gives me:

> Error: Invalid pattern '/home/runner/work/build-and-inspect-python-package/build-and-inspect-python-package/./action/requirements/tools.txt'. Relative pathing '.' and '..' is not allowed.

The old approach of

```yaml
cache-dependency-path: "**/tools.txt"
```

gives me:

> Error: No file in /home/runner/work/argon2-cffi-bindings/argon2-cffi-bindings matched to [**/tools.txt], make sure you have checked out the target repository

Because the action is hidden somewhere.

---

Not sure this is currently solvable…