### PR TITLE
Use /tmp as the build output directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- dist output files are written to `/tmp` instead of into the source `dist/` directory
 - *twine* now runs in `--strict` mode.
 - All tools are now pinned reliability (and hopefully caching in the future).
 - The action now uses `setup-python` itself to enable pinning (and hopefully caching in the future). Currently, Python 3.10 is used.

--- a/action.yml
+++ b/action.yml
@@ -27,12 +27,12 @@ runs:
       shell: bash
 
     # Build SDist, then build wheel out of it.
-    - run: /tmp/baipp/bin/python -m build
+    - run: /tmp/baipp/bin/python -m build --outdir /tmp/baipp-out
       shell: bash
       working-directory: ${{ inputs.path }}
 
     # Give user overview over what we've built.
-    - run: ls -l dist
+    - run: ls -l /tmp/baipp-out
       shell: bash
       working-directory: ${{ inputs.path }}
 
@@ -40,22 +40,22 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: Packages
-        path: ${{ inputs.path }}/dist/*
+        path: /tmp/baipp-out/*
 
-    - run: /tmp/baipp/bin/check-wheel-contents dist/*.whl
+    - run: /tmp/baipp/bin/check-wheel-contents /tmp/baipp-out/*.whl
       shell: bash
       working-directory: ${{ inputs.path }}
 
     - name: Check PyPI README
       shell: bash
       working-directory: ${{ inputs.path }}
-      run: /tmp/baipp/bin/python -m twine check --strict dist/*
+      run: /tmp/baipp/bin/python -m twine check --strict /tmp/baipp-out/*
 
     - name: Show wheel & SDist contents hierarchically.
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |
-        cd dist
+        cd /tmp/baipp-out
         mkdir -p out/wheels
         /tmp/baipp/bin/python -m wheel unpack --dest out/wheels *.whl
         mkdir -p out/sdist


### PR DESCRIPTION
Moving the output out of `inputs.path` allows other tools that are creating or working with the dists to assume that the entire contents of `dist/` are valid files.