### PR TITLE
Use unzip to unpack wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The action now uses [*uv*](https://github.com/astral-sh/uv) to install its tools to speed up your CI runs.
   [#86](https://github.com/hynek/build-and-inspect-python-package/pull/86)
 
+- We now use `unzip` to extract wheels, which preserves timestamps in the "Wheel contents" summary.
+  [#103](https://github.com/hynek/build-and-inspect-python-package/pull/103)
+
+
 
 ## [2.0.2](https://github.com/hynek/build-and-inspect-python-package/compare/v2.0.1...v2.0.2) – 2024-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   [#103](https://github.com/hynek/build-and-inspect-python-package/pull/103)
 
 
-
 ## [2.0.2](https://github.com/hynek/build-and-inspect-python-package/compare/v2.0.1...v2.0.2) – 2024-03-16
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
 
         if [[ "${{ inputs.skip-wheel }}" != 'true' ]]; then
             mkdir -p out/wheels
-            /tmp/baipp/bin/python -m wheel unpack --dest out/wheels *.whl
+            unzip *.whl -d out/wheels
 
             echo -e '\n<details><summary>Wheel contents</summary>\n' >> $GITHUB_STEP_SUMMARY
             (cd /tmp/baipp/dist/out/wheels && tree -Da --timefmt="%Y-%m-%dT%H:%M:%SZ" * | sed 's/^/    /' | tee -a $GITHUB_STEP_SUMMARY)


### PR DESCRIPTION
I have now gotten an heart attack at least twice because `wheel unpack` doesn't preserve the timestamps from the archive.