### PR TITLE
Attest build provenance of artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ env:
   SETUPTOOLS_SCM_PRETEND_VERSION: "1.0" # avoid warnings about shallow checkout
   UV_SYSTEM_PYTHON: "true"  # ensure action can deal with this set
 
-permissions:
-  id-token: write
-  attestations: write
-
 jobs:
   check-argon2-cffi-bindings:
     name: Build & verify the argon2-cffi-bindings package.
@@ -57,7 +53,6 @@ jobs:
         with:
           path: structlog
           upload-name-suffix: "-structlog"
-          attest-build-provenance-github: "true"
 
       - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
   SETUPTOOLS_SCM_PRETEND_VERSION: "1.0" # avoid warnings about shallow checkout
   UV_SYSTEM_PYTHON: "true"  # ensure action can deal with this set
 
+permissions:
+  id-token: write
+  attestations: write
+
 jobs:
   check-argon2-cffi-bindings:
     name: Build & verify the argon2-cffi-bindings package.
@@ -53,6 +57,7 @@ jobs:
         with:
           path: structlog
           upload-name-suffix: "-structlog"
+          attest-build-provenance-github: "true"
 
       - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/hynek/build-and-inspect-python-package/compare/v2.4.0...main)
 
+### Added
+
+- New input: `attest-build-provenance` generates signed build provenance attestations for workflow artifacts.
+  [#122](https://github.com/hynek/build-and-inspect-python-package/pull/122)
+
+
 ## [2.4.0](https://github.com/hynek/build-and-inspect-python-package/compare/v2.3.0...v2.4.0) - 2024-04-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- New input: `attest-build-provenance` generates signed build provenance attestations for workflow artifacts.
+- New input: `attest-build-provenance-github` generates signed build provenance attestations for workflow artifacts.
   [#122](https://github.com/hynek/build-and-inspect-python-package/pull/122)
 
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ While *build-and-inspect-python-package* will build a wheel for you by default, 
 
   Use this if you want to build multiple packages in one workflow.
   (*optional*, default: `''`).
-- `attest-build-provenance`: Whether to generate signed build provenance attestations for workflow artifacts using
-  [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance).
+- `attest-build-provenance-github`: Whether to generate signed build provenance attestations for workflow artifacts using [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance).
   Requires `attestations: write` and `id-token: write` permissions.
   The only meaningful value is `'true'` (note the quotes – GitHub Actions only allow string inputs) and everything else is treated as falsey.
   (*optional*, default: `'false'`).

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ While *build-and-inspect-python-package* will build a wheel for you by default, 
 
   Use this if you want to build multiple packages in one workflow.
   (*optional*, default: `''`).
+- `attest-build-provenance`: Whether to generate signed build provenance attestations for workflow artifacts using
+  [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance).
+  Requires `attestations: write` and `id-token: write` permissions.
+  The only meaningful value is `'true'` (note the quotes – GitHub Actions only allow string inputs) and everything else is treated as falsey.
+  (*optional*, default: `'false'`).
 
 
 ### Outputs

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,8 @@ inputs:
     description: Suffix to append to the artifact names.
     required: false
     default: ""
-  attest-build-provenance:
-    description: "Suffix to append to the artifact names. Requires 'attestations: write' and 'id-token: write' permissions."
+  attest-build-provenance-github:
+    description: "Attest provenance using GitHub's own action. Requires 'attestations: write' and 'id-token: write' permissions."
     required: false
     default: 'false'
 outputs:
@@ -106,8 +106,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
 
-    - name: Attest build provenance
-      if: ${{ inputs.attest-build-provenance == 'true' }}
+    - name: Attest GitHub build provenance
+      if: ${{ inputs.attest-build-provenance-github == 'true' }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: "/tmp/baipp/dist/*"

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: Suffix to append to the artifact names.
     required: false
     default: ""
+  attest-build-provenance:
+    description: "Suffix to append to the artifact names. Requires 'attestations: write' and 'id-token: write' permissions."
+    required: false
+    default: 'false'
 outputs:
   dist:
     description: The location of the built packages.
@@ -101,6 +105,12 @@ runs:
         fi
       shell: bash
       working-directory: ${{ inputs.path }}
+
+    - name: Attest build provenance
+      if: ${{ inputs.attest-build-provenance == 'true' }}
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: "/tmp/baipp/dist/*"
 
     - name: Set output
       id: dist-location-setter


### PR DESCRIPTION
Relates to https://github.com/hynek/build-and-inspect-python-package/issues/105.

Attest using https://github.com/actions/attest-build-provenance which uses Sigstore.

See https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/ for more info.

I'm not really sure how to test this, or if you want to add this. Feel free to take over, or close :)

---

It's very easy to add it to a regular workflow, for example:

https://github.com/hugovk/tinytext/commit/50f552061d0fb8a1b223a51044e73257a866e40c

It signs the files before uploading to PyPI.

Then you can download them from https://test.pypi.org/project/tinytext/3.6.1.dev93/#files and verify the owner or repo using the GitHub CLI:

```console
❯ gh attestation verify tinytext-3.6.1.dev94-py3-none-any.whl --owner hugovk
Loaded digest sha256:5933462a4b047f8d46cfd5dea3c27195ad569509bbfcb6d6e4a9cb2eed7329ad for file://tinytext-3.6.1.dev94-py3-none-any.whl
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:5933462a4b047f8d46cfd5dea3c27195ad569509bbfcb6d6e4a9cb2eed7329ad was attested by:
REPO             PREDICATE_TYPE                  WORKFLOW
hugovk/tinytext  https://slsa.dev/provenance/v1  .github/workflows/deploy.yml@refs/heads/main

❯ gh attestation verify tinytext-3.6.1.dev94.tar.gz --repo hugovk/tinytext
Loaded digest sha256:9813cf6a34fa06f6a649c50c2a50cad04df070b52f68343c067ffb3a0bb19539 for file://tinytext-3.6.1.dev94.tar.gz
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:9813cf6a34fa06f6a649c50c2a50cad04df070b52f68343c067ffb3a0bb19539 was attested by:
REPO             PREDICATE_TYPE                  WORKFLOW
hugovk/tinytext  https://slsa.dev/provenance/v1  .github/workflows/deploy.yml@refs/heads/main
```