### PR TITLE
Add output for name of uploaded artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           path: structlog
           upload-name-suffix: "-structlog-${{ matrix.os }}"
 
-      - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }}
+      - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }} and in artifact ${{ steps.baipp.outputs.artifact-name }}
 
   check-pytest:
     name: Build & verify the pytest package.
@@ -83,7 +83,7 @@ jobs:
           path: pytest
           upload-name-suffix: "-pytest"
 
-      - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }}
+      - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }} and in artifact ${{ steps.baipp.outputs.artifact-name }}
 
   required-checks-pass:
     name: Ensure everything required is passing for branch protection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support for `ubuntu-24.04` builders.
   [#126](https://github.com/hynek/build-and-inspect-python-package/pull/126)
 
+- New output: `artifact-name` is the name of the uploaded artifact.
+  [#125](https://github.com/hynek/build-and-inspect-python-package/pull/125)
 
 ## [2.5.0](https://github.com/hynek/build-and-inspect-python-package/compare/v2.4.0...v2.5.0) - 2024-05-13
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ While *build-and-inspect-python-package* will build a wheel for you by default, 
 
 ### Outputs
 
+- `artifact-name`: The name of the uploaded artifact.
+
 - `dist`: The location with the built packages.
 
   See, for example, how [*argon2-cffi-bindings*](https://github.com/hynek/argon2-cffi-bindings/blob/daff9ceb693312ab8257c60db4cd1c13cd866a35/.github/workflows/ci.yml#L83-L97) uses this feature to check the built wheels don’t break a package that depends on it.

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     required: false
     default: 'false'
 outputs:
+  artifact-name:
+    description: The name of the uploaded artifact.
+    value: ${{ steps.artifact.outputs.name }}
   dist:
     description: The location of the built packages.
     value: ${{ steps.dist-location-setter.outputs.dist }}
@@ -88,6 +91,11 @@ runs:
       env:
         VIRTUAL_ENV: /tmp/baipp
 
+    - name: Artifact Name
+      id: artifact
+      run: echo "name=Packages${{ inputs.upload-name-suffix }}" >>${GITHUB_OUTPUT}
+      shell: bash
+
     # Build SDist, then build wheel out of it if the user didn't forbid it.
     # Set 'SOURCE_DATE_EPOCH' based on the last commit for build
     # reproducibility.
@@ -125,7 +133,7 @@ runs:
     - name: Upload built artifacts.
       uses: actions/upload-artifact@v4
       with:
-        name: Packages${{ inputs.upload-name-suffix }}
+        name: ${{ steps.artifact.outputs.name }}
         path: /tmp/baipp/dist/*
 
     - name: Check wheel contents if one was built


### PR DESCRIPTION
I'd like to avoid needing to assume the name of the artifact in my downstream workflows.