### PR TITLE
Prune uv's CI cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/hynek/build-and-inspect-python-package/compare/v2.7.0...main)
 
+### Changed
+
+- Use *uv*'s new `uv cache prune --ci` to only cache downloaded files.
+  This makes the cache smaller and faster to pack/unpack.
+  [#135](https://github.com/hynek/build-and-inspect-python-package/pull/135)
+
+
+### Fixed
+
+- Turns out, the default location of *uv*'s cache cannot be cached and [*actions/cache*](https://github.com/actions/cache) fails silently with an opaque "Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved." log message.
+  We have moved the cache to `/tmp`.
+  [#135](https://github.com/hynek/build-and-inspect-python-package/pull/135)
+
 
 ## [2.7.0](https://github.com/hynek/build-and-inspect-python-package/compare/v2.6.0...v2.7.0) - 2024-07-17
 

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Set uv cache and hash lock file
       run: |
-        echo "UV_CACHE_DIR=/tmp/baipp/uv_cache_dir" >>$GITHUB_ENV
+        echo "UV_CACHE_DIR=/tmp/baipp-uv_cache_dir" >>$GITHUB_ENV
 
         echo "REQS_HASH=$(sha256sum ${{ github.action_path }}/requirements/tools.txt | cut -d' ' -f1)" >>$GITHUB_ENV
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -114,6 +114,10 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
 
+    - name: Optimize uv cache for CI
+      run: uv cache prune --ci
+      shell: bash
+
     - name: Attest GitHub build provenance
       if: ${{ inputs.attest-build-provenance-github == 'true' }}
       uses: actions/attest-build-provenance@v1

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
         echo "REQS_HASH=$(sha256sum ${{ github.action_path }}/requirements/tools.txt | cut -d' ' -f1)" >>$GITHUB_ENV
       shell: bash
 
-    - name: Restore uv cache
-      uses: actions/cache/restore@v4
+    - name: Setup uv cache
+      uses: actions/cache@v4
       with:
         path: ${{ env.UV_CACHE_DIR }}
         key: baipp-${{ env.REQS_HASH }}
@@ -107,31 +107,16 @@ runs:
         export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 
         if [[ "${{ inputs.skip-wheel }}" == "true" ]]; then
-          /tmp/baipp/bin/python -m build --installer=uv --sdist --outdir /tmp/baipp/dist
+          /tmp/baipp/bin/python -Im build --installer=uv --sdist --outdir /tmp/baipp/dist
         else
-          /tmp/baipp/bin/python -m build --installer=uv --outdir /tmp/baipp/dist
+          /tmp/baipp/bin/python -Im build --installer=uv --outdir /tmp/baipp/dist
         fi
       shell: bash
       working-directory: ${{ inputs.path }}
 
-
-    - name: debug pre
-      run: ls -al ${{ env.UV_CACHE_DIR }}
-      shell: bash
-
     - name: Optimize uv cache for CI
       run: uv cache prune --ci
       shell: bash
-
-    - name: debug post
-      run: ls -al ${{ env.UV_CACHE_DIR }}
-      shell: bash
-
-    - name: Save uv cache
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ env.UV_CACHE_DIR }}
-        key: baipp-${{ env.REQS_HASH }}
 
     - name: Attest GitHub build provenance
       if: ${{ inputs.attest-build-provenance-github == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
         echo "REQS_HASH=$(sha256sum ${{ github.action_path }}/requirements/tools.txt | cut -d' ' -f1)" >>$GITHUB_ENV
       shell: bash
 
-    - name: Cache uv
-      uses: actions/cache@v4
+    - name: Restore uv cache
+      uses: actions/cache/restore@v4
       with:
         path: ${{ env.UV_CACHE }}
         key: baipp-${{ env.REQS_HASH }}
@@ -117,6 +117,12 @@ runs:
     - name: Optimize uv cache for CI
       run: uv cache prune --ci
       shell: bash
+
+    - name: Save uv cache
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.UV_CACHE }}
+        key: baipp-${{ env.REQS_HASH }}
 
     - name: Attest GitHub build provenance
       if: ${{ inputs.attest-build-provenance-github == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -59,9 +59,9 @@ runs:
       run: curl -LsSf https://astral.sh/uv/install.sh | sh
       shell: bash
 
-    - name: Find uv cache and hash lock file
+    - name: Set uv cache and hash lock file
       run: |
-        echo "UV_CACHE=$(uv cache dir)" >>$GITHUB_ENV
+        echo "UV_CACHE_DIR=/tmp/baipp/uv_cache_dir" >>$GITHUB_ENV
 
         echo "REQS_HASH=$(sha256sum ${{ github.action_path }}/requirements/tools.txt | cut -d' ' -f1)" >>$GITHUB_ENV
       shell: bash
@@ -69,7 +69,7 @@ runs:
     - name: Restore uv cache
       uses: actions/cache/restore@v4
       with:
-        path: ${{ env.UV_CACHE }}
+        path: ${{ env.UV_CACHE_DIR }}
         key: baipp-${{ env.REQS_HASH }}
 
     - name: Create venv for tools
@@ -116,7 +116,7 @@ runs:
 
 
     - name: debug pre
-      run: ls -al /home/runner/.cache/uv
+      run: ls -al ${{ env.UV_CACHE_DIR }}
       shell: bash
 
     - name: Optimize uv cache for CI
@@ -124,13 +124,13 @@ runs:
       shell: bash
 
     - name: debug post
-      run: ls -al /home/runner/.cache/uv
+      run: ls -al ${{ env.UV_CACHE_DIR }}
       shell: bash
 
     - name: Save uv cache
       uses: actions/cache/save@v4
       with:
-        path: ${{ env.UV_CACHE }}
+        path: ${{ env.UV_CACHE_DIR }}
         key: baipp-${{ env.REQS_HASH }}
 
     - name: Attest GitHub build provenance

--- a/action.yml
+++ b/action.yml
@@ -114,8 +114,17 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
 
+
+    - name: debug pre
+      run: ls -al /home/runner/.cache/uv
+      shell: bash
+
     - name: Optimize uv cache for CI
       run: uv cache prune --ci
+      shell: bash
+
+    - name: debug post
+      run: ls -al /home/runner/.cache/uv
       shell: bash
 
     - name: Save uv cache


### PR DESCRIPTION
Just keep the downloaded packages to make cache operations faster.