### PR TITLE
Remove dist/.gitignore

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,6 +119,9 @@ runs:
         else
           uv build --out-dir /tmp/baipp/dist
         fi
+
+        # We don't need .gitignores and it litters the provenance output.
+        rm -f /tmp/baipp/dist/.gitignore
       shell: bash
       working-directory: ${{ inputs.path }}
 


### PR DESCRIPTION
It's new, unnecessary, and litters the provenance output.