### PR TITLE
Fix `package_version` example in readme to use `https://pypi.org/prokect/<package>/<version>/` instead of the `https://pypi.org/p/<package>/<version>/` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ While *build-and-inspect-python-package* will build a wheel for you by default, 
       needs: baipp
       environment:
         name: pypi
-        url: https://pypi.org/p/structlog/${{ needs.baipp.outputs.package-version }}
+        url: https://pypi.org/project/structlog/${{ needs.baipp.outputs.package-version }}
   ```
 
 ### Artifacts


### PR DESCRIPTION
Turns out this doesn't work

https://pypi.org/p/structlog/24.4.0/

but this does

https://pypi.org/project/structlog/24.4.0/