### PR TITLE
Switch to /tmp/baipp when syncing our tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/hynek/build-and-inspect-python-package/compare/v3.0.0...HEAD)
 
+### Fixed
+
+- To avoid *uv* configuration interference with the project that is being built, the installation of our own tools is now ran in a different directory.
+  Additionally, `UV_EXCLUDE_NEWER` is unset.
+  [#240](https://github.com/hynek/build-and-inspect-python-package/pull/240)
+
 
 ## [3.0.0](https://github.com/hynek/build-and-inspect-python-package/compare/v2.18.0...v3.0.0) - 2026-07-30
 

--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,7 @@ runs:
       run: |
         unset UV_SYSTEM_PYTHON
         unset UV_PYTHON
+        unset UV_EXCLUDE_NEWER
 
         uv venv \
           /tmp/baipp \

--- a/action.yml
+++ b/action.yml
@@ -119,6 +119,7 @@ runs:
         unset UV_PYTHON
 
         uv pip sync \
+          --directory=$VIRTUAL_ENV \
           ${GITHUB_ACTION_PATH}/requirements/tools.txt
       shell: bash
       env:


### PR DESCRIPTION
Otherwise, the project's uv config could interfere.

C.f. e.g.
https://github.com/hynek/svcs/actions/runs/30516479657/job/90787383111?pr=181 where the project's dependency cooldown prevented the installation of too-new build dependencies:

```
Using Python 3.14.6 environment at: /tmp/baipp
[102](https://github.com/hynek/svcs/actions/runs/30516479657/job/90787383111?pr=181#step:3:115)
    × No solution found when resolving dependencies:
[103](https://github.com/hynek/svcs/actions/runs/30516479657/job/90787383111?pr=181#step:3:116)
    ╰─▶ Because there is no version of annotated-types==0.8.0 and you require
[104](https://github.com/hynek/svcs/actions/runs/30516479657/job/90787383111?pr=181#step:3:117)
        annotated-types==0.8.0, we can conclude that your requirements are
[105](https://github.com/hynek/svcs/actions/runs/30516479657/job/90787383111?pr=181#step:3:118)
        unsatisfiable.
[106](https://github.com/hynek/svcs/actions/runs/30516479657/job/90787383111?pr=181#step:3:119)
  
[107](https://github.com/hynek/svcs/actions/runs/30516479657/job/90787383111?pr=181#step:3:120)
  hint: `annotated-types` was filtered by `exclude-newer` to only include packages uploaded before 2026-07-23T05:23:43.985813372Z. The requested version, v0.8.0, was published at 2026-07-23T20:16:12.938Z. Consider using `exclude-newer-package` to override the cutoff for this package.
```

